### PR TITLE
refactor: centralize configuration constants

### DIFF
--- a/lib/ComStateMachine/ComStateMachineMaster.cpp
+++ b/lib/ComStateMachine/ComStateMachineMaster.cpp
@@ -59,7 +59,7 @@ void ComStateMachineMaster::OnDataSent(uint8_t *mac_addr, uint8_t sendStatus) {
 }
 
 int ComStateMachineMaster::getDeviceIndex(MacAddress macAddress) {
-  for (uint8_t i = 0; i < MAX_NUMBER_DEVICES; i++) {
+  for (uint8_t i = 0; i < config::MAX_NUMBER_DEVICES; i++) {
     if (this->address[i] == macAddress) {
       return i;
     }
@@ -77,7 +77,7 @@ int ComStateMachineMaster::send(int deviceId) {
 };
 
 void ComStateMachineMaster::sendAll() {
-  for (uint8_t i = 0; i < MAX_NUMBER_DEVICES; i++) {
+  for (uint8_t i = 0; i < config::MAX_NUMBER_DEVICES; i++) {
     Serial.println("Sending");
     Serial.print("Sending payload type :");
     Serial.println(payload.payloadType);

--- a/lib/ComStateMachine/ComStateMachineMaster.h
+++ b/lib/ComStateMachine/ComStateMachineMaster.h
@@ -5,8 +5,7 @@
 #include "ComStateMachineI.h"
 #include "EventBroker.h"
 #include "LedStateMachine.h"
-
-#define MAX_NUMBER_DEVICES 5
+#include "Constants.h"
 
 enum ComStateMaster {
   STANDBY,
@@ -21,7 +20,7 @@ enum ComStateMaster {
 
 class ComStateMachineMaster : public ComStateMachineI {
  private:
-  MacAddress address[MAX_NUMBER_DEVICES];
+  MacAddress address[config::MAX_NUMBER_DEVICES];
   ComStateMaster comState = ComStateMaster::STANDBY;
   int getDeviceIndex(MacAddress macAddress);
   EventBroker *eventBroker;

--- a/lib/ComStateMachine/ComStateMachineSlave.cpp
+++ b/lib/ComStateMachine/ComStateMachineSlave.cpp
@@ -89,7 +89,7 @@ void ComStateMachineSlave::update()
 	}
 	case ComStateSlave::PAIRING:
 	{
-		if (millis() - previous > RETRY_DELAY)
+                if (millis() - previous > config::RETRY_DELAY)
 		{
 			Serial.println(millis());
 			if (send() == 0)
@@ -117,7 +117,7 @@ void ComStateMachineSlave::update()
 			server.setMacAddress(receivedPayload.macAddress);
 			esp_now_add_peer(receivedPayload.macAddress, ESP_NOW_ROLE_COMBO, 1, NULL, 0);
 		}
-		else if (millis() - previous > ACK_TIMEOUT)
+                else if (millis() - previous > config::ACK_TIMEOUT)
 		{
 			Serial.println(millis() - previous);
 			Serial.println("APP timed out");

--- a/lib/ComStateMachine/ComStateMachineSlave.h
+++ b/lib/ComStateMachine/ComStateMachineSlave.h
@@ -7,9 +7,7 @@
 #include <MacAddress.h>
 
 #include "ComStateMachineI.h"
-
-#define RETRY_DELAY 500
-#define ACK_TIMEOUT 2000
+#include "Constants.h"
 
 enum class ComStateSlave
 {

--- a/lib/Constants/Constants.h
+++ b/lib/Constants/Constants.h
@@ -1,27 +1,35 @@
+#pragma once
+
+#include <Arduino.h>
+
+namespace config {
 
 // WiFi
-#define RETRY_DELAY 500
-#define ACK_TIMEOUT 2000
+constexpr uint16_t RETRY_DELAY = 500;
+constexpr uint16_t ACK_TIMEOUT = 2000;
 
 // EventBroker
-#define EVENTQSIZE 5
+constexpr uint8_t EVENTQSIZE = 5;
 
 // ComStateMachine
-#define MAX_NUMBER_DEVICES 5
+constexpr uint8_t MAX_NUMBER_DEVICES = 5;
 
 // LED
-#define NUM_LEDS 4
-#define LED_DATA_PIN D4
-#define ANIMATION_TIME 3000
+constexpr uint8_t NUM_LEDS = 4;
+constexpr uint8_t LED_DATA_PIN = D4;
+constexpr unsigned long ANIMATION_TIME = 3000;
 
 // Screen
-#define SCREEN_WIDTH 128
-#define SCREEN_HEIGHT 32
-#define OLED_RESET -1
-#define SCREEN_ADDRESS 0x3C
+constexpr uint8_t SCREEN_WIDTH = 128;
+constexpr uint8_t SCREEN_HEIGHT = 32;
+constexpr int8_t OLED_RESET = -1;
+constexpr uint8_t SCREEN_ADDRESS = 0x3C;
 
 // Buzzer
-#define BUZZER_PIN D5
+constexpr uint8_t BUZZER_PIN = D5;
 
 // Button
-#define BUTTON_PIN D7
+constexpr uint8_t BUTTON_PIN = D7;
+
+}  // namespace config
+

--- a/lib/EventBroker/EventBroker.h
+++ b/lib/EventBroker/EventBroker.h
@@ -1,8 +1,7 @@
 #pragma once
 #include <stdint.h>
 #include "HardwareSerial.h"
-
-#define EVENTQSIZE 5
+#include "Constants.h"
 
 enum class EventType
 {
@@ -21,9 +20,9 @@ struct Event
 class EventBroker
 {
 private:
-	uint8_t bufferSize = EVENTQSIZE;
-	uint8_t eventsInBuffer = 0;
-	Event events[EVENTQSIZE];
+        uint8_t bufferSize = config::EVENTQSIZE;
+        uint8_t eventsInBuffer = 0;
+        Event events[config::EVENTQSIZE];
 
 public:
 	void addEvent(Event);

--- a/lib/GameStateMachine/GameStateMachine.h
+++ b/lib/GameStateMachine/GameStateMachine.h
@@ -4,8 +4,6 @@
 #include "EventBroker.h"
 #include "ComStateMachineMaster.h"
 
-#define ANIMATION_TIME 3000
-
 enum class GameState
 {
 	SETUP,

--- a/lib/LedStateMachine/LedStateMachine.cpp
+++ b/lib/LedStateMachine/LedStateMachine.cpp
@@ -10,11 +10,11 @@ double nExp(const double x, const double coef)
 	return (exp(x * coef) - 1) / (exp(coef) - 1);
 }
 
-void smoothRotation(const CRGB &color, const unsigned int period, CRGB (&leds)[NUM_LEDS])
+void smoothRotation(const CRGB &color, const unsigned int period, CRGB (&leds)[config::NUM_LEDS])
 {
-	for (int i = 0; i < NUM_LEDS; i++)
-	{
-		double intensity = nExp(nSin(millis(), period, (double)i / NUM_LEDS), 1);
+        for (int i = 0; i < config::NUM_LEDS; i++)
+        {
+                double intensity = nExp(nSin(millis(), period, (double)i / config::NUM_LEDS), 1);
 		leds[i].red = color.red * intensity;
 		leds[i].green = color.green * intensity;
 		leds[i].blue = color.blue * intensity;
@@ -22,16 +22,16 @@ void smoothRotation(const CRGB &color, const unsigned int period, CRGB (&leds)[N
 	FastLED.show();
 }
 
-void breathe(const CRGB &color, const unsigned int period, CRGB (&leds)[NUM_LEDS], uint8_t depth)
+void breathe(const CRGB &color, const unsigned int period, CRGB (&leds)[config::NUM_LEDS], uint8_t depth)
 {
-	double intensity = nExp(nSin(millis(), period, 0), 1) * (double)depth / 255 + 1 - (double)depth / 255;
-	fill_solid(leds, NUM_LEDS, CRGB(color.r * intensity, color.g * intensity, color.b * intensity));
-	FastLED.show();
+        double intensity = nExp(nSin(millis(), period, 0), 1) * (double)depth / 255 + 1 - (double)depth / 255;
+        fill_solid(leds, config::NUM_LEDS, CRGB(color.r * intensity, color.g * intensity, color.b * intensity));
+        FastLED.show();
 }
 
 void LedStateMachine::init()
 {
-	FastLED.addLeds<WS2812, LED_DATA_PIN, GRB>(leds, NUM_LEDS); // GRB ordering is typical
+        FastLED.addLeds<WS2812, config::LED_DATA_PIN, GRB>(leds, config::NUM_LEDS); // GRB ordering is typical
 	FastLED.setBrightness(50);
 }
 LedState previous = LedState::IDLE;
@@ -57,7 +57,7 @@ void LedStateMachine::update()
 		if (previous != LedState::OFF)
 		{
 			previous = LedState::OFF;
-			fill_solid(leds, NUM_LEDS, CRGB::Black);
+                        fill_solid(leds, config::NUM_LEDS, CRGB::Black);
 			FastLED.show();
 			Serial.println("LED STATE : OFF");
 		}
@@ -104,7 +104,7 @@ void LedStateMachine::update()
 		if (previous != LedState::ERROR)
 		{
 			previous = LedState::ERROR;
-			fill_solid(leds, NUM_LEDS, CRGB::Red);
+                        fill_solid(leds, config::NUM_LEDS, CRGB::Red);
 			FastLED.show();
 			Serial.println("LED STATE : ERROR");
 			this->ledState = LedState::IDLE;

--- a/lib/LedStateMachine/LedStateMachine.h
+++ b/lib/LedStateMachine/LedStateMachine.h
@@ -1,9 +1,6 @@
 #pragma once
 #include <FastLED.h>
-#define NUM_LEDS 4
-#define LED_DATA_PIN D4
-
-#define ANIMATION_TIME 3000
+#include "Constants.h"
 
 enum class LedState
 {
@@ -20,7 +17,7 @@ class LedStateMachine
 {
 private:
 	LedState ledState = LedState::OFF;
-	CRGB leds[NUM_LEDS];
+        CRGB leds[config::NUM_LEDS];
 	unsigned long timer = 0;
 
 public:

--- a/lib/ScreenStateMachine/ScreenStateMachine.cpp
+++ b/lib/ScreenStateMachine/ScreenStateMachine.cpp
@@ -3,7 +3,7 @@
 void ScreenStateMachine::init(EventBroker *eventBroker)
 {
 	this->eventBroker = eventBroker;
-	if (!display.begin(SSD1306_SWITCHCAPVCC, SCREEN_ADDRESS))
+        if (!display.begin(SSD1306_SWITCHCAPVCC, config::SCREEN_ADDRESS))
 	{
 		Serial.println(F("SSD1306 allocation failed"));
 	}

--- a/lib/ScreenStateMachine/ScreenStateMachine.h
+++ b/lib/ScreenStateMachine/ScreenStateMachine.h
@@ -1,40 +1,38 @@
 #pragma once
+
 #include <SPI.h>
 #include <Wire.h>
 #include <Adafruit_GFX.h>
 #include <Adafruit_SSD1306.h>
+
 #include "EventBroker.h"
+#include "Constants.h"
 
-#define SCREEN_WIDTH 128 // OLED display width, in pixels
-#define SCREEN_HEIGHT 32 // OLED display height, in pixels
-
-#define OLED_RESET -1		// Reset pin # (or -1 if sharing Arduino reset pin)
-#define SCREEN_ADDRESS 0x3C ///< See datasheet for Address; 0x3D for 128x64, 0x3C for 128x32
-
-enum class ScreenState
-{
-	OFF,
-	COUNTING,
-	PAUSED
+enum class ScreenState {
+        OFF,
+        COUNTING,
+        PAUSED
 };
 
-class ScreenStateMachine
-{
+class ScreenStateMachine {
 private:
-	Adafruit_SSD1306 display;
-	EventBroker *eventBroker;
-	ScreenState screenState = ScreenState::COUNTING;
-	unsigned long total = 0;
-	unsigned long start = 0;
-	unsigned long getMillis();
-	String getTime();
-	void printTime();
-	ScreenState previous = ScreenState::OFF;
+        Adafruit_SSD1306 display;
+        EventBroker *eventBroker;
+        ScreenState screenState = ScreenState::COUNTING;
+        unsigned long total = 0;
+        unsigned long start = 0;
+        unsigned long getMillis();
+        String getTime();
+        void printTime();
+        ScreenState previous = ScreenState::OFF;
 
 public:
-	ScreenStateMachine() : display(SCREEN_WIDTH, SCREEN_HEIGHT, &Wire, OLED_RESET){};
-	void init(EventBroker *);
-	void update();
-	void setState(ScreenState);
-	ScreenState getState();
+        ScreenStateMachine()
+            : display(config::SCREEN_WIDTH, config::SCREEN_HEIGHT, &Wire,
+                      config::OLED_RESET){};
+        void init(EventBroker *);
+        void update();
+        void setState(ScreenState);
+        ScreenState getState();
 };
+

--- a/src/main-master.cpp
+++ b/src/main-master.cpp
@@ -35,7 +35,7 @@ void setup()
 
   ledStateMachine.init();
 
-  button.attach(BUTTON_PIN, INPUT_PULLUP);
+  button.attach(config::BUTTON_PIN, INPUT_PULLUP);
   button.interval(50);
 
   comStateMachineMaster.init(&ledStateMachine, &eventBroker);
@@ -45,7 +45,7 @@ void setup()
   // get the status of Trasnmitted packet
   esp_now_set_self_role(ESP_NOW_ROLE_COMBO);
 
-  pinMode(BUZZER_PIN, OUTPUT);
+  pinMode(config::BUZZER_PIN, OUTPUT);
 }
 
 void loop()
@@ -55,9 +55,9 @@ void loop()
   {
     for (int i = 0; i < 100; i++)
     {
-      digitalWrite(BUZZER_PIN, LOW);
+      digitalWrite(config::BUZZER_PIN, LOW);
       delayMicroseconds(125);
-      digitalWrite(BUZZER_PIN, HIGH);
+      digitalWrite(config::BUZZER_PIN, HIGH);
       delayMicroseconds(125);
     }
     Event event;


### PR DESCRIPTION
## Summary
- replace scattered macros with `constexpr` values in `Constants.h`
- update modules to include `Constants.h` and use namespaced config values
- ensure event queue, LED, and pin definitions share a single source of truth

## Testing
- `pio test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895f41e6f4c832b8bf1e77bcd40fbb1